### PR TITLE
Minor fixes for cmake-build-x64.bat

### DIFF
--- a/cmake-build-x64.bat
+++ b/cmake-build-x64.bat
@@ -50,12 +50,12 @@ if not exist "%CMAKE%" goto CMakeNotFound
 if not exist "%LUXCORE_ROOT%" goto LuxCoreNotFound
 
 :: Determine if we have CMake 2 or 3
-for /F "tokens=3" %%G in ('cmake --version ^| find "cmake version"') do set CMAKE_VER=%%G
+for /F "tokens=3" %%G in ('%CMAKE% --version ^| find "cmake version"') do set CMAKE_VER=%%G
 for /F "tokens=1 delims=." %%G in ("%CMAKE_VER%") do set CMAKE_VN_MAJOR=%%G
 echo We are using CMake version: %CMAKE_VN_MAJOR%
 :: Default values
 set CMAKE_GENERATOR="Visual Studio 15 2017"
-set CMAKE_TOOLSET=-T v141_xp
+set CMAKE_TOOLSET=-T v141
 if "%CPU_PLATFORM%"=="x64" (
   set CMAKE_PLATFORM=-A %CPU_PLATFORM%
 ) else (


### PR DESCRIPTION
Firstly use CMAKE variable instead of cmake.exe, in my case I copy cmake folder into WindowsCompileDeps/bin/cmake so that cmake.exe is not in system path.

Secondly, drop the support for windows XP. 