### PR TITLE
Invoke 64bit linker directly, saves some build time.

### DIFF
--- a/cmake-build-x64.bat
+++ b/cmake-build-x64.bat
@@ -55,7 +55,7 @@ for /F "tokens=1 delims=." %%G in ("%CMAKE_VER%") do set CMAKE_VN_MAJOR=%%G
 echo We are using CMake version: %CMAKE_VN_MAJOR%
 :: Default values
 set CMAKE_GENERATOR="Visual Studio 15 2017"
-set CMAKE_TOOLSET=-T v141
+set CMAKE_TOOLSET=-T v141,host=x64
 if "%CPU_PLATFORM%"=="x64" (
   set CMAKE_PLATFORM=-A %CPU_PLATFORM%
 ) else (


### PR DESCRIPTION
Hi,
default VS behaviour is to invoke 32 bit linker first, even on 64 bit hosts, then it switches to 64 bit when more memory needs are detected.